### PR TITLE
商品詳細表示機能3

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,9 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
-  # def show
-  #   @item = Item.find(params[:id])
-  # end
+  def show
+    @item = Item.find(params[:id])
+  end
+
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,12 +23,15 @@
       </span>
     </div>
 
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %> 
-      <p class='or-text'>or</p>
-      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %> 
-    <%# <% if @item.item_purchase.present? %> %>
-      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? %>
+      <%if current_user.id == @item.user_id %>
+        <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %> 
+        <p class='or-text'>or</p>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %> 
+      <% end %>
+      <% if current_user.id != @item.user_id %>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn" %>
+      <% end %>
     <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,14 +28,13 @@
         <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %> 
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %> 
-      <% end %>
-      <% if current_user.id != @item.user_id %>
+      <% else current_user.id != @item.user_id %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn" %>
       <% end %>
     <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.introduction %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -101,7 +100,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href=“#” class=‘another-item’><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href=“#” class=‘another-item’><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
         <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %> 
         <p class='or-text'>or</p>
         <%= link_to '削除', "#", method: :delete, class:'item-destroy' %> 
-      <% else current_user.id != @item.user_id %>
+      <% else %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn" %>
       <% end %>
     <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,11 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-    <%# # 商品詳細機能 8,11,20,23,27,29,31 %>
-      <%# <%= @item.name %> %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%# <%= image_tag @item.image ,class:"item-box-img" %> %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
        <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -17,25 +16,20 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%# ¥ <%= @item.price %> %>
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%# <%= @item.delivery_cost_id  %>
+        <%= @item.delivery_cost.name %>
       </span>
     </div>
 
-    <%# <% if user_signed_in? && current_user.id == @item.user_id %> %>
-
-    <%# <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %> %>
-    <p class='or-text'>or</p>
-    <%# <%= link_to '削除', "/items/#{@item.id}", method: :delete, class:'item-destroy' %> %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# <% end %> %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', edit_item_path, method: :get, class: "item-red-btn" %> 
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %> 
+    <%# <% if @item.item_purchase.present? %> %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -44,27 +38,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_days.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
# What
商品詳細機能の実装

# Why
トップページの該当商品から詳細情報を確認できるようにするため

・ログイン状態の出品者のみ、「編集・削除ボタン」が表示されること：https://gyazo.com/d2e3c5fe66fa411e172f125b974f8409
・ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されること：https://gyazo.com/1ba6417ebfac6de331aad30602e0d9b3
・ログアウト状態のユーザーは商品詳細表示ページを閲覧できるが、「編集・削除・購入画面に進むボタン」は表示されないこと：https://gyazo.com/2acb263574683173bfccc0c700bcd35e
・商品出品時に登録した情報が見られるようになっていること：https://gyazo.com/30288210f73c34f3641d206693d3355b

※・ログイン状態の出品者でも、売却済みの商品に対しては「編集・削除ボタン」が表示されないこと→「売却済み」を判定する実装をまだしておりませんので、購入機能実装後でも構いませんか？
