### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create ]
+  before_action :authenticate_user!, only: [:new, :create, :edit ]
 
   def index
     @items = Item.all.order(id: "DESC")
@@ -22,6 +22,21 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+    unless current_user.id == @item.user_id
+      redirect_to root_path
+    end
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to show
+    else 
+      render :edit
+    end
+  end
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit ]
+  before_action :item_find, except: [:index, :new, :create]
+  before_action :redirect_root, only: [:edit, :update]
 
   def index
     @items = Item.all.order(id: "DESC")
@@ -19,18 +21,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
-    unless current_user.id == @item.user_id
-      redirect_to root_path
-    end
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to show
     else 
@@ -42,6 +38,16 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:image, :name, :introduction, :category_id, :condition_id, :delivery_cost_id, :prefecture_id, :delivery_days_id, :price).merge(user_id: current_user.id)
+  end
+
+  def item_find
+    @item = Item.find(params[:id])
+  end
+
+  def redirect_root
+    unless current_user.id == @item.user_id
+      redirect_to root_path
+    end
   end
 
 end

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -146,7 +146,7 @@
     <% end %>
     <%# /下部ボタン %>
   </div>
- <% end %>
+<% end %>
 
 <footer class="items-sell-footer">
   <ul class="menu">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,4 +1,3 @@
- <%# 商品編集機能 %>
-<%# <div class="items-sell-contents">
- <%= render partial: 'form', locals:{ item: @item } %>
-</div> %>
+ <div class="items-sell-contents"> 
+  <%= render partial: 'form', locals:{ item: @item } %>
+</div> 


### PR DESCRIPTION
# What
商品情報編集機能

# Why
出品者が売却前の商品情報を編集できるようにするため

- 必要な情報を適切に入力すると商品情報を変更できること：https://gyazo.com/52b67ac39d938ba59b70bf83764369d9
- 何も編集せずに更新をしても画像無しの商品にならないこと：https://gyazo.com/67086efb0847023d45fdde7222289f3e
- ログイン状態の出品者だけが商品情報編集ページに遷移できること
      ログイン状態の出品者は商品情報編集ページに遷移できること：https://gyazo.com/c3c92b415808d3a7f9d886e0e55c6080
　　ログイン状態の出品者以外のユーザーは商品情報編集ページに遷移できないこと：https://gyazo.com/92a84b1df6f2b84a06fce81ea61a3241
　　ログアウト状態のユーザーは出品情報編集ページに遷移できないこと：https://gyazo.com/d2f5c968840ad2e74de6a31df7f0eee6
- ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとするとトップページに遷移すること：https://gyazo.com/3dbeb33b510e3974dc628674233f76cd
- ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移すること：https://gyazo.com/14e9fd92621ff402d30e4457551452c1

- 商品出品時とほぼ同じ見た目で商品情報編集機能が実装されていること→共通のビューファイルを使用するよう実装
- 画像以外すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること：https://gyazo.com/daaa8f4fb14fbf1e8120cddc0dfba31e
- 商品情報編集ページにてエラーハンドリングができていること：https://gyazo.com/42f6fb61ae8755d5eb2c185b80941629

<商品購入機能実施後確認する要件＞
- 出品者・出品者以外にかかわらずログイン状態のユーザーがURLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること
- ログアウト状態のユーザーが、URLを直接入力して売却済み商品の商品情報編集ページへ遷移しようとすると、ログインページに遷移すること